### PR TITLE
Python3 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
-build
 choldate/build
-choldate/build
-choldate/choldate.so
 choldate/choldate.c
+choldate/*.so
 build
+*.egg-info/
 
 .DS_Store
 

--- a/choldate/__init__.py
+++ b/choldate/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'jasonrudy'
 #__all__ = ['choldate','choldate.test']
-from _choldate import cholupdate, choldowndate
+from ._choldate import cholupdate, choldowndate


### PR DESCRIPTION
Under Python3 an absolute import like "from _choldate import ..." needs to instead be a relative import "from ._choldate import ...". Both work under Python2, so this makes the package compatible with both. `choldate/test/test.py` seems happy under Python3 now with just this change.
