### PR TITLE
fixing url to follow URL security change 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Somewhat fast updating and downdating of Cholesky factors in Python
 
 ##installation
 
-Install from GitHub: `pip install git+git://github.com/jcrudy/choldate.git`
+Install from GitHub: `pip install git+https://github.com/jcrudy/choldate.git`
 
 Or, clone the GitHub repository and install from source, e.g.,
 


### PR DESCRIPTION
Changing `git://` to `https://` to follow security change 
https://github.blog/2021-09-01-improving-git-protocol-security-github/#how-do-i-prepare